### PR TITLE
Changes from background agent bc-8b2a0e27-9b1c-48d8-b812-c2f55831e952

### DIFF
--- a/lean_digital_twin.py
+++ b/lean_digital_twin.py
@@ -225,7 +225,6 @@ class LeanDigitalTwin(ttk.Frame):
         self.last_preview_ts = None
 
         # --- shared variables for repo/prefix (fix for geometry mixing) ---
-        self.repo_var = tk.StringVar(value=self.settings.get("repo_url", ""))
         self.prefix_var = tk.StringVar(value=self.settings.get("sparql_prefix", "PREFIX ex: <http://example.org/pumps#>"))
 
         self._configure_styles()
@@ -301,13 +300,12 @@ class LeanDigitalTwin(ttk.Frame):
 
         # 1. Semantic Network URL
         ttk.Label(left, text="Semantic Network URL:").grid(row=0, column=0, sticky="w", pady=(0, 2))
-        self.url_var = tk.StringVar(value=self.settings.get("sparql_url", ""))
+        self.url_var = tk.StringVar(value=self.settings.get("repo_url", ""))
         url_entry = ttk.Entry(left, textvariable=self.url_var, width=40)
         url_entry.grid(row=1, column=0, sticky="ew", pady=(0, 8))
 
         # 2. SPARQL Prefix
         ttk.Label(left, text="SPARQL Prefix:").grid(row=2, column=0, sticky="w", pady=(0, 2))
-        self.prefix_var = tk.StringVar(value=self.settings.get("sparql_prefix", ""))
         prefix_entry = ttk.Entry(left, textvariable=self.prefix_var, width=40)
         prefix_entry.grid(row=3, column=0, sticky="ew", pady=(0, 8))
 


### PR DESCRIPTION
Unify repository URL variable and fix duplicate SPARQL prefix initialization to resolve configuration errors.

The application was using `self.repo_var` and `self.url_var` interchangeably for the repository URL, causing the "Repository URL is not set" error despite user input. This PR standardizes the use of `self.url_var` for the repository URL, ensuring it's correctly loaded from and saved to `settings.json` under the "repo_url" key. It also removes a redundant re-initialization of `self.prefix_var` within `_build_graphical_model_tab`, preventing potential overwrites of the user-defined prefix.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b2a0e27-9b1c-48d8-b812-c2f55831e952">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b2a0e27-9b1c-48d8-b812-c2f55831e952">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

